### PR TITLE
#13 #16 Introduced a headline / body system for notes

### DIFF
--- a/lua/ghostnotes/config.lua
+++ b/lua/ghostnotes/config.lua
@@ -17,3 +17,4 @@ function M.setup(user_opts)
 end
 
 return M
+


### PR DESCRIPTION
 When creating a note you can add it with only a headline or a headline
 + body. When you have both a headline and a body you will see only the headline inline as virtual text. This is done to prevent a massively long virtual line when you create full markdown notes for example.

Also made the finder only display the headline

Closes #16 