### PR TITLE
fix: suggested lazy setup not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,14 @@ If neither telescope nor snacks is installed you will get a simple picker that l
 lazy.nvim:
 
 ```lua
-return {
-  "vvilhelmsen/ghostnotes.nvim",
-  config = function()
-    require("ghostnotes").setup({
-      -- Optional overrides, for example:
-      -- note_prefix = "📝 ",
-      -- path_options = ":p",
-    })
-  end,
-}
+{
+    dir = "~/Projects/ghostnotes.nvim",
+    opts = {
+        -- Optional overrides, for example:
+        -- note_prefix = "📝 ",
+        -- path_options = ":p",
+    }
+},
 ````
 ---
 

--- a/lua/ghostnotes/init.lua
+++ b/lua/ghostnotes/init.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.config(user_opts)
+function M.setup(user_opts)
   require("ghostnotes.config").setup(user_opts)
   require("ghostnotes.core").init()
 end


### PR DESCRIPTION
The function "setup" from the example is really named "config" in init.lua. 
Renamed it to "setup", since this is what gets called by lazy.nvim. 
Updated the example to use "opts" for "config", which is recommended by lazy.