### PR TITLE
Feature/telescope picker colors

### DIFF
--- a/lua/ghostnotes/config.lua
+++ b/lua/ghostnotes/config.lua
@@ -11,6 +11,18 @@ M.opts = {
 	},
 	namespace = "ghostnotes",
 	note_prefix = "👻 ",
+  picker = {
+    highlighting = {
+      file = "Normal",
+      row = "lineNr",
+      head = "String",
+    },
+    boundaries = {
+      file = { min = 5, max = 25 },
+      row = { min = 0, max = nil },
+    },
+    separator = " "
+  },
 
     -- Some modifiers:
     -- :p   - Absolute path

--- a/lua/ghostnotes/finder/common.lua
+++ b/lua/ghostnotes/finder/common.lua
@@ -1,0 +1,91 @@
+local config        = require("ghostnotes.config").opts
+local get_head      = require("ghostnotes.note_operations.getters").get_note_headline
+
+local M             = {}
+
+local hl            = config.picker.highlighting
+local bo            = config.picker.boundaries
+
+local function oneline(s)
+  s = (s or ""):gsub("%s+", " ")
+  if #s > 200 then s = s:sub(1, 200) .. "…" end
+  return s
+end
+
+M.build_items = function(notes, path_format)
+  local out = {}
+  for _, n in ipairs(notes or {}) do
+    local file = vim.fn.fnamemodify(n.bufname, path_format)
+    local head = get_head(n)
+    local row = (n.row or 0) + 1
+    local display = file .. ":" .. row .. " → " .. head
+    local body = oneline(n.text)
+    table.insert(out, {
+      bufname   = n.bufname,
+      row       = row,
+      note_text = n.text,
+      head      = head,
+      timestamp = n.timestamp,
+      -- right now grepping only works if we display the body. Looks ugly but works
+      text      = body ~= "" and (display .. " — " .. body) or display,
+      file      = file,
+      display   = display
+    })
+  end
+  return out
+end
+
+M.tel_create_displayer = function(items)
+  local entry_display = require "telescope.pickers.entry_display"
+  local function calc_field_length(name, entries, min, max)
+    local length = min or 0
+    for _, entry in pairs(entries) do
+      local field = tostring(entry[name])
+      if field and #field > length then
+        length = #field
+        if max and length >= max then return end
+      end
+    end
+    return length
+  end
+
+  local displayer = entry_display.create({
+    separator = config.picker.separator,
+    items = {
+      { width = calc_field_length("file", items, bo.file.min, bo.file.min) },
+      { width = calc_field_length("row", items, bo.row.min, bo.row.max) },
+      { remaining = true }
+    }
+  })
+
+  local function make_display(entry)
+    local val = entry.value
+    return displayer {
+      { val.file, hl.file },
+      { val.row,  hl.row },
+      { val.head, hl.head },
+    }
+  end
+
+  return make_display
+end
+
+M.tel_previewer = function()
+  local previewers = require("telescope.previewers")
+
+  return previewers.new_buffer_previewer({
+    title = "Note Preview",
+    define_preview = function(self, entry, _)
+      local note = entry.value
+      local lines = {}
+      for line in (note.note_text or ""):gmatch("([^\n]*)\n?") do
+        table.insert(lines, line)
+      end
+      if #lines == 0 then lines = { "(Empty note)" } end
+      vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+      vim.api.nvim_set_option_value("filetype", "markdown", { scope = "local", buf = self.state.bufnr })
+    end,
+  })
+end
+
+return M

--- a/lua/ghostnotes/finder/find_notes_project.lua
+++ b/lua/ghostnotes/finder/find_notes_project.lua
@@ -3,6 +3,8 @@ local config = require("ghostnotes.config")
 local ns = vim.api.nvim_create_namespace(config.opts.namespace)
 local path_format = config.opts.path_format or ":t"
 local get_note_headline = require("ghostnotes.note_operations.getters").get_note_headline
+local build_items = require("ghostnotes.finder.common").build_items
+
 local M = {}
 
 -- (used by both picker types)
@@ -117,32 +119,15 @@ function M.find_notes_project()
 
 	local path = git_root .. "/.ghostnotes.json"
 	local project_notes = utils.read_json(path)
+	local items = build_items(project_notes, path_format)
 	if vim.tbl_isempty(project_notes) then
 		vim.notify("No project ghost notes", vim.log.levels.INFO)
 		return
 	end
 
 	if Snacks and Snacks.picker then
-		local picker_items = {}
-		for _, note in ipairs(project_notes) do
-			local display_text = vim.fn.fnamemodify(note.bufname, path_format)
-				.. ":"
-				.. ((note.row or 0) + 1)
-				.. " → "
-				.. get_note_headline(note)
-
-			table.insert(picker_items, {
-				bufname = note.bufname,
-				row = note.row,
-				note_text = note.text, -- Avoid conflict
-				timestamp = note.timestamp,
-				file = note.bufname,
-				text = display_text,
-			})
-		end
-
 		Snacks.picker.pick({
-			items = picker_items,
+			items = items,
 			prompt = "> ",
 			title = "Ghost Notes (Project)",
 			format = "text",
@@ -180,45 +165,22 @@ function M.find_notes_project()
 			local conf = require("telescope.config").values
 			local actions = require("telescope.actions")
 			local action_state = require("telescope.actions.state")
-			local previewers = require("telescope.previewers")
 
-			local note_previewer = previewers.new_buffer_previewer({
-				title = "Note Preview",
-				define_preview = function(self, entry, status)
-					local note = entry.value
-					-- Clear the buffer
-					vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, {})
-
-					local lines = {}
-					for line in note.text:gmatch("([^\n]*)\n?") do
-						table.insert(lines, line)
-					end
-
-					if #lines > 0 then
-						vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-					else
-						vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, { "(Empty note)" })
-					end
-
-          vim.api.nvim_set_option_value("filetype", "markdown", { scope = "local", buf = self.state.bufnr })
-				end,
-			})
+      local make_display = require("ghostnotes.finder.common").tel_create_displayer(items)
+      local note_previewer = require("ghostnotes.finder.common").tel_previewer()
 
 			pickers
 				.new({}, {
 					prompt_title = "Ghost Notes (Project)",
 					finder = finders.new_table({
-						results = project_notes,
-						entry_maker = function(note)
-							local name = vim.fn.fnamemodify(note.bufname, ":t")
-							local headline = get_note_headline(note)
-							local display = name .. ":" .. ((note.row or 0) + 1) .. " → " .. headline
-							return {
-								value = note,
-								display = display,
-								ordinal = display,
-							}
-						end,
+						results = items,
+            entry_maker = function(it)
+              return {
+                value   = it,
+                display = make_display,
+                ordinal = it.display
+              }
+            end
 					}),
 					sorter = conf.generic_sorter({}),
 					previewer = note_previewer,


### PR DESCRIPTION
Using `telescope.pickers.entry_display` to display highlighted columns
for the picker.

Added attributes for highlighting and column width to the default
config.

Moved some common utility functions for setting up pickers to one
location.

This also removes the need to display text in the grep picker.